### PR TITLE
Make kernel version to generate headers for configurable in CI

### DIFF
--- a/.github/workflows/vmlinux.h.yml
+++ b/.github/workflows/vmlinux.h.yml
@@ -6,6 +6,12 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      kernel-ref:
+        description: 'Kernel version (Git tag/ref)'
+        required: true
+        # Keep in sync with string used in `checkout` invocation below.
+        default: 'v6.18'
   workflow_call:
 
 jobs:
@@ -31,7 +37,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: 'torvalds/linux'
-          ref: 'v6.18'
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.kernel-ref || 'v6.18' }}
           fetch-depth: 1
           path: linux/
 


### PR DESCRIPTION
Make the kernel version to generate headers for configurable when triggered from the UI. Because Actions are stupid, we can't introduce a constant and have to hardcode the default twice -- at least if we want users to see what version to generate for by default. So at least make sure to keep the definition in the same file by not making it an input to the workflow_call event as well.